### PR TITLE
Fix os_neutron and etcd handler naming conflict.

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Reload systemd daemon
+- name: Run systemctl daemon reload
   command: "systemctl daemon-reload"
   notify:
     - Restart neutron services

--- a/tasks/neutron_init_systemd.yml
+++ b/tasks/neutron_init_systemd.yml
@@ -49,7 +49,7 @@
     group: "root"
   with_items: "{{ filtered_neutron_services }}"
   notify:
-    - Reload systemd daemon
+    - Run systemctl daemon reload
 
 - name: Place the systemd init script
   config_template:
@@ -62,4 +62,4 @@
     config_type: "ini"
   with_items: "{{ filtered_neutron_services }}"
   notify:
-    - Reload systemd daemon
+    - Run systemctl daemon reload


### PR DESCRIPTION
The handler to do a 'systemctl daemon-reload' in both os_neutron
and the etcd dependancy have the same name.  This was causing the
etcd one to run which was being skipped.  The end result was the
neutron services were stuck running old code and never reset on
upgrades.  Renaming the os_neutron handler for reloading the
daemon seems to fix the issue and run the handler from os_neutron
without being skipped as before.

JIRA: RE-1296